### PR TITLE
Use procfs crate for reading thread priority

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ thread_local = "1.1.4"
 
 [dev-dependencies]
 nix = { version = "0.25.0", default-features = false, features = ["user"] }
+procfs = { version = "0.14.0", default-features = false }
 
 [[test]]
 name = "tests"


### PR DESCRIPTION
Leverage the `procfs` crate for reading the thread priority in tests. No need for us to parse the filesystem ourselves.