### PR TITLE
Implement lock_api::RawMutexTimed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 libc = "0.2.126"
-linux-futex = "0.1.1"
+linux-futex = "0.1.2"
 lock_api = "0.4.7"
 once_cell = "1.12.0"
 thread_local = "1.1.4"


### PR DESCRIPTION
Provide support for timed lock-attempts. This requires bumping the dependency on linux-futex to pull in a bug fix for handling `std::time::Instant::now()`.