### PR TITLE
Remove thread_local dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased] - ReleaseDate
+
+- Remove `thread_local` dependency.
+
 ## [0.2.0] - 2022-08-16
 
 - Added try-lock timeout support via `lock_api::RawMutexTimed`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ libc = "0.2.126"
 linux-futex = "0.1.2"
 lock_api = "0.4.7"
 once_cell = "1.12.0"
-thread_local = "1.1.4"
 
 [dev-dependencies]
 nix = { version = "0.25.0", default-features = false, features = ["user"] }


### PR DESCRIPTION
This wasn't actually used or required.