### PR TITLE
Add cargo-semver-checks GitHub Action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,3 +47,13 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+  semver:
+    name: Check semver (must manually inspect)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check semver (must manually inspect)
+        uses: obi1kenobi/cargo-semver-checks-action@v1
+        continue-on-error: true


### PR DESCRIPTION
Currently configured such that the build should always pass, meaning we need to manually inspect the results.

This isn't ideal, but GitHub Actions don't appear to support any sort of "warning" status.