### PR TITLE
Remove dependency on archived actions-rs steps

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,40 +13,28 @@ jobs:
           - beta
           - nightly
           - 1.69.0 # MSRV
+        target:
+          - aarch64-linux-android
+          - x86_64-unknown-linux-gnu
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Setup rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-          components: rustfmt, clippy
+      - run: rustup toolchain add --profile=minimal ${{ matrix.rust }} --component clippy --component rustfmt
 
-      - name: cargo build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
+      - run: rustup target add --toolchain=${{ matrix.rust }} ${{ matrix.target }}
 
-      - name: cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - run: cargo +${{ matrix.rust }} build --target=${{ matrix.target }}
 
-      - name: cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: cargo +${{ matrix.rust }} test
 
-      - name: cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+      - if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: cargo +${{ matrix.rust }} fmt --all --check
+
+      - if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: cargo +${{ matrix.rust }} clippy -- -D warnings
 
   semver:
     name: Check semver (must manually inspect)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Updated `libc` dependency to 0.2.155.
 - Updated `linux-futex` dependency to 1.0.0.
 - Updated `lock_api` dependency to 0.4.12.
+- Add support for `aarch64-linux-android`.
 
 ## [0.3.0] - 2023-11-26
 


### PR DESCRIPTION
This also validates our new support for `aarch64-linux-android`, enabled by https://github.com/rust-lang/libc/commit/fceb18ee4154d55063d1bfaaeef5c0fa3ed4b83b and https://github.com/m-ou-se/linux-futex/commit/31ea8c7904e628d86b0001c69a550e352b20ed69.